### PR TITLE
chore: readme style change to heading (WEB-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# 🌟 Spanish Learning MCP (Model Context Protocol)
+
+# <div align="center">🌟 Spanish Learning MCP (Model Context Protocol)</div>
+
 
 <div align="center">
   <img src="https://img.shields.io/badge/TypeScript-007ACC?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript">
@@ -9,7 +11,7 @@
 
 <div align="center">
   <p><em>A comprehensive implementation of Model Context Protocol for Spanish language learning</em></p>
-  <p>Created by Danny Thompson (DThompsonDev) at This Dot Labs</p>
+  <p>Created by Danny Thompson (DThompsonDev) at <a href="https://thisdot.co">This Dot Labs</a></p>
 </div>
 <img width="1069" alt="image" src="https://github.com/user-attachments/assets/f1411864-ec5a-4ff5-8ec8-53bf71be6c38" />
 


### PR DESCRIPTION
We should now see the Headline centered and the This Dot Labs name as a hyperlink

With change
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d0184f8a-a7ab-4568-bf9e-8e81bd9841c4" />

Before change
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d5e8ffc9-8d03-46eb-aad3-8f8ac7e165f6" />
